### PR TITLE
Fix Docker build permission error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,13 @@ RUN apt-get update && \
     apt-get install -y nginx curl supervisor dnsutils && \
     apt-get clean
 
+# Copy supervisor config
+COPY supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Copy the startup script and make it executable
+COPY supervisor/start.sh /usr/local/bin/start.sh
+RUN chmod +x /usr/local/bin/start.sh
+
 # Create a non-root user
 RUN useradd -m -u 1000 user
 USER user
@@ -75,13 +82,7 @@ EXPOSE 8080
 # ============================================
 # Stage 3: Start FastAPI + Nginx in parallel 
 # ============================================
-# Copy supervisor config
-COPY supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
 
 ## using a dedicated script..
-# Copy the startup script and make it executable
-COPY supervisor/start.sh /usr/local/bin/start.sh
-RUN chmod +x /usr/local/bin/start.sh
-
 CMD ["/usr/local/bin/start.sh"]


### PR DESCRIPTION
This commit fixes a Docker build permission error that occurred when trying to make the `start.sh` script executable. The error was caused by switching to a non-root user before changing the permissions of the script.

The fix moves the `COPY` and `chmod` commands for the startup script and the `COPY` for the supervisor config to before the `USER` directive.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
