### PR TITLE
Fix Docker build permission errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ COPY supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY supervisor/start.sh /usr/local/bin/start.sh
 RUN chmod +x /usr/local/bin/start.sh
 
+# Copy custom nginx config
+COPY nginx-proxy/nginx.conf /etc/nginx/conf.d/default.conf
+RUN chown user:user /etc/nginx/conf.d/default.conf
+
 # Create a non-root user
 RUN useradd -m -u 1000 user
 USER user
@@ -71,9 +75,6 @@ RUN mkdir -p /home/user/app/log /home/user/app/proposal-documents /home/user/app
 COPY --chown=user:user ./backend/knowledge/*.json /home/user/app/knowledge/
 # Let's confirm the file exists in the right place
 RUN echo "Checking knowledge dir after copy:" && ls -la /home/user/app/knowledge
-
-# Copy custom nginx config
-COPY nginx-proxy/nginx.conf /etc/nginx/conf.d/default.conf
 
 # Expose Cloud Run default port
 EXPOSE 8080


### PR DESCRIPTION
This commit fixes Docker build permission errors that occurred when trying to make the `start.sh` script executable and when `sed` tried to modify the `nginx.conf` file. The errors were caused by switching to a non-root user before changing the permissions of the script and the ownership of the Nginx config file.

The fix moves the `COPY` and `chmod`/`chown` commands for the startup script, supervisor config, and Nginx config to before the `USER` directive.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
