### PR TITLE
Fix Docker build permission errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN apt-get update && \
     apt-get install -y nginx curl supervisor dnsutils && \
     apt-get clean
 
+# Create a non-root user
+RUN useradd -m -u 1000 user
+
 # Copy supervisor config
 COPY supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
@@ -32,8 +35,6 @@ RUN chmod +x /usr/local/bin/start.sh
 COPY nginx-proxy/nginx.conf /etc/nginx/conf.d/default.conf
 RUN chown user:user /etc/nginx/conf.d/default.conf
 
-# Create a non-root user
-RUN useradd -m -u 1000 user
 USER user
 
 # Create a working directory


### PR DESCRIPTION
This commit fixes Docker build permission errors that occurred when trying to change the ownership of files to a user that had not yet been created.

The fix moves the `useradd` command to before any `chown` commands.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
