### PR TITLE
feat: add markdown table support for display and export

### DIFF
--- a/backend/api/documents.py
+++ b/backend/api/documents.py
@@ -14,7 +14,7 @@ from sqlalchemy import text
 from backend.core.db import get_engine
 from backend.core.security import get_current_user
 from backend.core.config import SECTIONS
-from backend.utils.doc_export import add_markdown_paragraph, create_pdf_from_sections
+from backend.utils.doc_export import create_word_from_sections, create_pdf_from_sections
 
 # This router handles endpoints for generating and downloading final proposal documents.
 router = APIRouter()
@@ -59,29 +59,6 @@ async def generate_and_download_document(
 
         ordered_sections = {section: generated_sections.get(section, "") for section in SECTIONS}
 
-        # --- Create Word Document (.docx) ---
-        doc = Document()
-        doc.add_heading("Project Proposal", level=1)
-
-        # Add form data as a table.
-        table = doc.add_table(rows=1, cols=2)
-        table.style = 'Table Grid'
-        hdr_cells = table.rows[0].cells
-        hdr_cells[0].text = 'Field'
-        hdr_cells[1].text = 'Value'
-        for key, value in form_data.items():
-            row_cells = table.add_row().cells
-            row_cells[0].text = key
-            row_cells[1].text = str(value) # Ensure value is a string
-        doc.add_paragraph("\n")
-
-        # Add the main content sections.
-        for section, content in ordered_sections.items():
-            doc.add_heading(section, level=2)
-            for para in (content or "").split("\n\n"):
-                add_markdown_paragraph(doc, para.strip())
-
-        # --- Save and Return File ---
         if format == "pdf":
             try:
                 pdf_buffer = create_pdf_from_sections(form_data, ordered_sections)
@@ -95,6 +72,7 @@ async def generate_and_download_document(
                 raise HTTPException(status_code=500, detail="Failed to generate PDF document.")
         else:
             # Return the DOCX file by default.
+            doc = create_word_from_sections(form_data, ordered_sections)
             docx_buffer = io.BytesIO()
             doc.save(docx_buffer)
             docx_buffer.seek(0)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,8 +3,10 @@ fastapi
 redis
 crewai>=0.1.48
 litellm>=1.73.7
-openai<1.99.9 
+openai<1.99.9
 python-docx
+markdown-it-py
+mdit-py-plugins
 langchain
 langchain-openai
 langchain-community

--- a/backend/utils/doc_export.py
+++ b/backend/utils/doc_export.py
@@ -1,53 +1,121 @@
-#  Standard Library
+# Standard Library
 import re
 from typing import Dict
 
-#  Third-Party Libraries
+# Third-Party Libraries
 from docx import Document
 from docx.shared import Pt
-from reportlab.lib.pagesizes import A4
-from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle
-from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
-from reportlab.lib.enums import TA_JUSTIFY
+from markdown_it import MarkdownIt
+from mdit_py_plugins.front_matter import front_matter_plugin
+from mdit_py_plugins.table import table_plugin
 from reportlab.lib import colors
+from reportlab.lib.enums import TA_JUSTIFY
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
 from reportlab.lib.units import inch
+from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
 
-#  Internal Modules
+# Internal Modules
 from backend.utils.markdown import convert_markdown_bold
 
-# This module contains helper functions for creating and exporting documents
-# in different formats, such as .docx (Word) and .pdf.
 
-def add_markdown_paragraph(doc: Document, text: str):
+def add_markdown_to_doc(doc: Document, text: str):
     """
-    Adds a paragraph to a .docx document, correctly handling Markdown bold syntax.
+    Adds content to a .docx document, correctly handling Markdown syntax.
 
-    It splits the text by the bold markers (**) and adds runs to the paragraph,
-    applying bold formatting where necessary.
+    This function parses the Markdown text and adds elements to the document,
+    including paragraphs with bold text and tables.
 
     Args:
         doc: The python-docx Document object.
-        text: The paragraph text, which may contain Markdown bold.
+        text: The text, which may contain Markdown syntax.
     """
-    paragraph = doc.add_paragraph()
-    # Split the text by bold markdown delimiters.
-    parts = re.split(r'(\*\*.*?\*\*)', text)
+    # Configure the Markdown parser to handle tables.
+    md = MarkdownIt().use(front_matter_plugin).use(table_plugin)
+    tokens = md.parse(text)
 
-    for part in parts:
-        if part.startswith("**") and part.endswith("**"):
-            # If the part is wrapped in **, add it as a bold run.
-            paragraph.add_run(part[2:-2]).bold = True
-        else:
-            # Otherwise, add it as a normal run.
-            paragraph.add_run(part)
+    for token in tokens:
+        if token.type == "table_open":
+            # Create a table in the document.
+            table_data = []
+            headers = []
+            # Extract table headers.
+            for th in tokens[tokens.index(token) + 2].children:
+                if th.type == "text":
+                    headers.append(th.content)
+            # Create the table with the correct number of columns.
+            table = doc.add_table(rows=1, cols=len(headers))
+            table.style = "Table Grid"
+            hdr_cells = table.rows[0].cells
+            # Populate table headers.
+            for i, header in enumerate(headers):
+                hdr_cells[i].text = header
+            # Extract and populate table rows.
+            for tr in tokens[tokens.index(token) + 4:]:
+                if tr.type == "tr_open":
+                    row_cells = table.add_row().cells
+                    cell_index = 0
+                    for td in tr.children:
+                        if td.type == "text":
+                            row_cells[cell_index].text = td.content
+                            cell_index += 1
+        elif token.type == "paragraph_open":
+            # Handle paragraphs, including bold text.
+            paragraph = doc.add_paragraph()
+            for child in token.children:
+                if child.type == "strong_open":
+                    # Add bold text.
+                    run = paragraph.add_run(child.next_sibling.content)
+                    run.bold = True
+                elif child.type == "text" and not child.find_predecessor("strong_open"):
+                    # Add regular text.
+                    paragraph.add_run(child.content)
+            # Apply paragraph formatting.
+            paragraph.paragraph_format.space_after = Pt(12)
+            paragraph.paragraph_format.line_spacing = 1.5
 
-    # Apply standard paragraph formatting.
-    paragraph.paragraph_format.space_after = Pt(12)
-    paragraph.paragraph_format.line_spacing = 1.5
+
+def create_word_from_sections(form_data: Dict, ordered_sections: Dict) -> Document:
+    """
+    Generates a .docx document from proposal data.
+
+    Args:
+        form_data: A dictionary containing the proposal's metadata.
+        ordered_sections: A dictionary of the proposal sections and their content.
+
+    Returns:
+        A python-docx Document object.
+    """
+    doc = Document()
+    # Add the main title.
+    doc.add_heading("Project Proposal", level=1)
+
+    # Add the form data as a table.
+    doc.add_heading("Project Details", level=2)
+    table = doc.add_table(rows=1, cols=2)
+    table.style = "Table Grid"
+    hdr_cells = table.rows[0].cells
+    hdr_cells[0].text = "Field"
+    hdr_cells[1].text = "Value"
+    for key, value in form_data.items():
+        row_cells = table.add_row().cells
+        row_cells[0].text = key
+        row_cells[1].text = str(value)
+
+    # Add each proposal section to the document.
+    for section, content in ordered_sections.items():
+        if not content:
+            continue  # Skip empty sections.
+        doc.add_heading(section, level=2)
+        add_markdown_to_doc(doc, content)
+
+    return doc
 
 
 #  Standard Library
 import io
+
+
 def create_pdf_from_sections(form_data: Dict, ordered_sections: Dict) -> bytes:
     """
     Generates a PDF document from proposal data using ReportLab and returns it as a byte buffer.
@@ -60,21 +128,18 @@ def create_pdf_from_sections(form_data: Dict, ordered_sections: Dict) -> bytes:
         A byte buffer containing the generated PDF.
     """
     buffer = io.BytesIO()
-    doc = SimpleDocTemplate(buffer, pagesize=A4, rightMargin=72, leftMargin=72, topMargin=72, bottomMargin=72)
+    doc = SimpleDocTemplate(
+        buffer, pagesize=A4, rightMargin=72, leftMargin=72, topMargin=72, bottomMargin=72
+    )
     styles = getSampleStyleSheet()
 
     # Define a custom style for justified body text.
-    normal_style = ParagraphStyle(
-        name='Body',
-        parent=styles['Normal'],
-        alignment=TA_JUSTIFY,
-        leading=14
-    )
+    normal_style = ParagraphStyle(name="Body", parent=styles["Normal"], alignment=TA_JUSTIFY, leading=14)
 
     story = []
 
     # Add the main title.
-    story.append(Paragraph("Project Proposal", styles['Title']))
+    story.append(Paragraph("Project Proposal", styles["Title"]))
     story.append(Spacer(1, 12))
 
     # Create a table for the form data.
@@ -83,15 +148,19 @@ def create_pdf_from_sections(form_data: Dict, ordered_sections: Dict) -> bytes:
         table_data.append([key, str(value)])
 
     table = Table(table_data, colWidths=[2.5 * inch, 3.5 * inch])
-    table.setStyle(TableStyle([
-        ('BACKGROUND', (0, 0), (-1, 0), colors.lightgrey),
-        ('TEXTCOLOR', (0, 0), (-1, 0), colors.black),
-        ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
-        ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-        ('FONTSIZE', (0, 0), (-1, -1), 10),
-        ('BOTTOMPADDING', (0, 0), (-1, 0), 8),
-        ('GRID', (0, 0), (-1, -1), 0.5, colors.grey),
-    ]))
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.black),
+                ("ALIGN", (0, 0), (-1, -1), "LEFT"),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 10),
+                ("BOTTOMPADDING", (0, 0), (-1, 0), 8),
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+            ]
+        )
+    )
     story.append(table)
     story.append(Spacer(1, 20))
 
@@ -100,7 +169,7 @@ def create_pdf_from_sections(form_data: Dict, ordered_sections: Dict) -> bytes:
         if not content:
             continue  # Skip empty sections.
 
-        story.append(Paragraph(section, styles['Heading2']))
+        story.append(Paragraph(section, styles["Heading2"]))
         story.append(Spacer(1, 6))
 
         # Split content into paragraphs and format them.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.4.0"
+    "react-router-dom": "^7.4.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/frontend/src/screens/Chat/Chat.jsx
+++ b/frontend/src/screens/Chat/Chat.jsx
@@ -3,6 +3,7 @@ import './Chat.css'
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 
 import Base from '../../components/Base/Base'
 import CommonButton from '../../components/CommonButton/CommonButton'
@@ -741,7 +742,7 @@ export default function Chat (props)
                                                                                 (selectedSection === i && isEdit) ?
                                                                                         <textarea value={editorContent} onChange={e => setEditorContent(e.target.value)} aria-label={`editor for ${sectionObj[0]}`} />
                                                                                         :
-                                                                                        <Markdown>{sectionObj[1].content}</Markdown>
+                                                                                        <Markdown remarkPlugins={[remarkGfm]}>{sectionObj[1].content}</Markdown>
                                                                                 :
                                                                                 <div className='Chat_sectionContent_loading'>
                                                                                         <span className='submitButtonSpinner' />


### PR DESCRIPTION
This commit introduces support for rendering markdown tables correctly both in the frontend chat interface and in the exported .docx report.

- Frontend: The `remark-gfm` plugin has been added to `react-markdown` to enable GitHub Flavored Markdown rendering, which includes tables.
- Backend: The `markdown-it-py` library has been added to parse markdown content. The .docx export logic has been refactored to use this library, allowing it to correctly identify and create tables in the Word document.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
