### PR TITLE
fix(frontend): Resolve infinite loop in section generation

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,6 @@
 # Backend Application
 
-This directory contains the backend of the proposal drafting application, built with FastAPI.
+This directory contains the backend of the proposal drafting application, built with FastAPI. It handles user authentication, proposal data management, and AI-powered content generation.
 
 ## Code Structure
 
@@ -10,40 +10,66 @@ The backend code is organized into the following modules:
 
 -   **`api/`**: This module contains the API endpoints, with each file representing a different domain.
     -   `auth.py`: User authentication endpoints (signup, login, logout, etc.).
-    -   `proposals.py`: Endpoints for managing proposals (creation, editing, listing, etc.).
-    -   `session.py`: Endpoints for managing temporary user session data in Redis.
+    -   `proposals.py`: Endpoints for managing the entire proposal lifecycle.
     -   `documents.py`: Endpoints for generating and downloading proposal documents.
     -   `health.py`: Health check and debugging endpoints.
 
 -   **`core/`**: This module contains the core components of the application.
-    -   `config.py`: Application configuration, including environment variable loading and CORS settings.
-    -   `db.py`: Database connection logic, including the SQLAlchemy engine.
-    -   `llm.py`: Language model initialization and configuration.
-    -   `middleware.py`: Custom middleware, such as CORS and exception handlers.
-    -   `redis.py`: Redis client initialization with a fallback to in-memory storage.
-    -   `security.py`: Security-related functions, such as authentication and password management.
+    -   `config.py`: Application configuration, environment variable loading, and template discovery.
+    -   `db.py`: Database connection logic using SQLAlchemy.
+    -   `redis.py`: Redis client initialization for session management.
+    -   `security.py`: Security-related functions for authentication and authorization.
 
 -   **`models/`**: This module contains the Pydantic models for data validation.
-    -   `schemas.py`: Pydantic models for request and response data.
+    -   `schemas.py`: Pydantic models for all API request and response data.
 
 -   **`utils/`**: This module contains utility functions.
     -   `crew.py`: Defines the CrewAI agents and tasks for proposal generation.
-    -   `doc_export.py`: Helper functions for creating and exporting documents.
+    -   `doc_export.py`: Helper functions for creating and exporting `.docx` and `.pdf` documents.
     -   `markdown.py`: Helper functions for handling Markdown conversions.
-    -   `proposal_logic.py`: Core logic for generating and regenerating proposal sections.
+    -   `proposal_logic.py`: Core logic for regenerating proposal sections.
+
+-   **`templates/`**: Contains the JSON proposal templates that define the structure and sections for different donors.
 
 -   **`tests/`**: This directory contains the tests for the backend application.
 
-## Running the Application
+## Proposal Generation Workflow
 
-To run the application locally, you will need to have Docker and Docker Compose installed. From the root of the project, run:
+The backend follows a specific workflow for creating and generating a new proposal, designed to be robust and ensure data consistency.
 
-```bash
-docker-compose up --build
+1.  **Template Discovery (`GET /templates`)**: The frontend first requests the list of available proposal templates. The backend scans the `templates/` directory, reads each JSON file, and returns a map of donor names to template filenames.
+
+2.  **Session Creation (`POST /create-session`)**: When a user fills out the initial form and clicks "Generate", the frontend sends the form data and project description to this endpoint. The backend then:
+    a. Determines the correct template based on the "Targeted Donor" in the form data.
+    b. Creates a new proposal record in the PostgreSQL database.
+    c. Creates a new session in Redis containing all the necessary context (form data, project description, and the full proposal template).
+    d. Returns the `proposal_id` and `session_id` to the frontend.
+
+3.  **Section Processing (`POST /process_section/{session_id}`)**: The frontend iterates through the sections defined in the template and calls this endpoint for each one. To ensure the AI has the latest information, the frontend sends the **current form data and project description** with every request. The backend updates the Redis session with this fresh data before kicking off the CrewAI generation process.
+
+4.  **Manual Edits (`POST /update-section-content`)**: If a user manually edits a section, the frontend calls this dedicated endpoint. It directly updates the content for that section in the PostgreSQL database, bypassing the AI for a fast and reliable save.
+
+5.  **Document Generation (`GET /generate-document/{proposal_id}`)**: When a user requests to download the document, the backend fetches the proposal from the database, loads the appropriate template to ensure correct section ordering, and generates the requested file (`.docx` or `.pdf`).
+
+## Proposal Template Format
+
+Each proposal template is a `.json` file located in the `templates/` directory. To be discovered correctly by the backend, each template file must be a JSON object (not a list) and contain a `donors` key.
+
+-   **`donors`**: A list of strings, where each string is a donor name that can use this template. This allows a single template to be associated with multiple donors.
+
+Example:
+```json
+{
+  "donors": ["UNHCR", "IOM"],
+  "project_info": { ... },
+  "sections": [ ... ]
+}
 ```
 
-The application will be available at `http://localhost:8080`.
+## Running the Application
+
+For detailed instructions on running the application locally (with and without Docker) and deploying to Azure, please refer to the main `CICD-SETUP.md` file in the root of the project.
 
 ## Environment Variables
 
-The application uses environment variables for configuration. You can find a list of the required variables in `.env.example`. Create a `.env` file in this directory with your own values.
+The application uses environment variables for configuration. You can find a list of the required variables in `.env.example`. Create a `.env` file in this directory with your own values when running locally.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,32 +6,51 @@ This directory contains the frontend of the proposal drafting application, built
 
 The frontend code is organized into the following directories:
 
--   **`public/`**: This directory contains static assets that are publicly accessible, such as the application's favicon.
-
--   **`src/`**: This is the main directory for the application's source code.
-    -   **`assets/`**: This directory contains static assets that are imported into the application, such as images and fonts.
-    -   **`components/`**: This directory contains reusable React components that are used throughout the application.
-    -   **`screens/`**: This directory contains the main screens or pages of the application. Each screen is a combination of components and represents a distinct view in the application.
-    -   **`mocks/`**: This directory contains mock data and server handlers for testing purposes.
-    -   **`App.jsx`**: The main application component. It sets up the application's routing and renders the different screens.
-    -   **`main.jsx`**: The entry point of the application. It renders the `App` component into the DOM.
+-   **`public/`**: Contains static assets that are publicly accessible.
+-   **`src/`**: The main directory for the application's source code.
+    -   **`assets/`**: Contains static assets imported into the application, such as images and fonts.
+    -   **`components/`**: Contains reusable React components used throughout the application.
+    -   **`screens/`**: Contains the main screens or pages of the application.
+    -   **`mocks/`**: Contains mock data and server handlers for testing.
+    -   **`App.jsx`**: The main application component, which sets up routing.
+    -   **`main.jsx`**: The entry point of the application.
     -   **`index.css`**: The main stylesheet for the application.
 
--   **`vite.config.js`**: The configuration file for Vite, the build tool used by the application.
+## Key Components and Logic
 
--   **`vitest.config.js`**: The configuration file for Vitest, the testing framework used by the application.
+The core of the user experience is handled by two main screen components:
+
+### `screens/Dashboard/Dashboard.jsx`
+
+-   **Responsibility**: This component serves as the user's home page after logging in. It displays a list of all existing proposal drafts and sample proposals.
+-   **API Interaction**: On load, it makes a `GET` request to the `/api/list-drafts` endpoint to fetch the list of proposals.
+-   **User Flow**:
+    -   A user can click "Generate New Proposal" to navigate to the `/chat` screen to start a new proposal.
+    -   A user can click on an existing draft, which stores the `proposal_id` in `sessionStorage` and navigates to the `/chat` screen to load it for editing.
+
+### `screens/Chat/Chat.jsx`
+
+-   **Responsibility**: This is the main workspace for creating, viewing, and editing a proposal. It handles the proposal form, the generation of sections, and the display of results.
+-   **State Management**: It uses React's `useState` and `useEffect` hooks to manage the form data, the project description, the proposal sections, and the overall UI state (e.g., loading indicators).
+-   **API Interaction and Workflow**:
+    1.  **Template Loading**: On component mount, it fetches the available donor-to-template mappings from the `/api/templates` endpoint and populates the "Targeted Donor" dropdown.
+    2.  **Creating a New Proposal**:
+        - When the user clicks "Generate", it calls the `POST /api/create-session` endpoint, sending the form data and project description.
+        - It receives a `session_id` and `proposal_id` from the backend, storing them in `sessionStorage`.
+        - It then triggers the `getSections` function to start generating content.
+    3.  **Loading an Existing Proposal**:
+        - If a `proposal_id` is found in `sessionStorage`, it calls `GET /api/load-draft/{proposal_id}` to fetch the existing proposal data and populate the form and results.
+    4.  **Generating Sections**:
+        - The `getSections` function iterates through the list of sections for the proposal and calls `POST /api/process_section/{session_id}` for each one.
+        - Crucially, it sends the **latest form data** with each call to ensure the backend is always working with fresh information.
+    5.  **Saving Manual Edits**:
+        - When a user manually edits a section and clicks "Save", the component calls the `POST /api/update-section-content` endpoint.
+        - This provides a direct, fast way to save content without involving the AI generation process.
 
 ## Running the Application
 
-To run the application locally, you will need to have Node.js and npm installed. From this directory, run:
-
-```bash
-npm install
-npm run dev
-```
-
-The application will be available at `http://localhost:8503`.
+For detailed instructions on running the application locally, please refer to the main `CICD-SETUP.md` file in the root of the project.
 
 ## Environment Variables
 
-The application uses environment variables for configuration. You can find a list of the required variables in `.env.example`. Create a `.env` file in this directory with your own values.
+The application uses environment variables for configuration. The primary variable is `VITE_BACKEND_URL`, which should point to the URL of the running backend API. Refer to `.env.example` for details.


### PR DESCRIPTION
This commit fixes a bug in the frontend where the proposal generation process would get stuck in an infinite loop.

The issue was caused by a race condition in `Chat.jsx`. The `useEffect` hook responsible for triggering section generation was dependent on the `proposal` state. The generation function itself updated this state inside a loop, causing the `useEffect` to be re-triggered continuously.

The fix involves refactoring the generation logic:
- A single `useEffect` is now used to kick off the generation process, and it only depends on the `generateLoading` state.
- The `generateAllSections` async function now handles the entire sequential loop of fetching sections. It is no longer re-triggered by its own state updates.
- This ensures the generation process runs exactly once from start to finish, resolving the infinite loop.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
