### PR TITLE
Fix dashboard popover regression and disable edit buttons

### DIFF
--- a/frontend/src/screens/Chat/Chat.jsx
+++ b/frontend/src/screens/Chat/Chat.jsx
@@ -967,7 +967,7 @@ export default function Chat (props)
                                                         Results
                                                 </div>
 
-                                                {Object.values(proposal).some(section => section.content) ? <div className='Chat_exportButtons'>
+                                                {Object.keys(proposal).length > 0 && Object.values(proposal).every(section => section.content) ? <div className='Chat_exportButtons'>
                                                         <button type="button" onClick={() => handleExport("docx")}>
                                                                 <img src={word_icon} />
                                                                 Download Document
@@ -1041,7 +1041,7 @@ export default function Chat (props)
                                                                          <div className="Chat_sectionTitle">{sectionName}</div>
 
                                                                         {!generateLoading && sectionObj[1].content && sectionObj[1].open && !isApproved ? <div className="Chat_sectionOptions" data-testid={`section-options-${i}`}>
-                                                                                {!isEdit || (selectedSection === i && isEdit) ? <button type="button" onClick={() => handleEditClick(i)} style={(selectedSection === i && isEdit && regenerateSectionLoading) ? {pointerEvents: "none"} : {}} aria-label={`edit-section-${i}`}>
+                                                                                {!isEdit || (selectedSection === i && isEdit) ? <button type="button" onClick={() => handleEditClick(i)} style={(selectedSection === i && isEdit && regenerateSectionLoading) ? {pointerEvents: "none"} : {}} aria-label={`edit-section-${i}`} disabled={proposalStatus === 'in_review'}>
                                                                                         <img src={(selectedSection === i && isEdit) ? save : edit} />
                                                                                         <span>{(selectedSection === i && isEdit) ? "Save" : "Edit"}</span>
                                                                                 </button> : "" }

--- a/frontend/src/screens/Dashboard/components/Project/Project.css
+++ b/frontend/src/screens/Dashboard/components/Project/Project.css
@@ -24,6 +24,11 @@
     z-index: 10;
 }
 
+.Dashboard_project.disabled {
+    cursor: not-allowed;
+    background-color: #f9f9f9;
+}
+
 .Dashboard_project_title {
         display: flex;
         justify-content: space-between;
@@ -85,6 +90,16 @@
 
 .Project_optionsPopover_option > img {
         height: 16px;
+}
+
+.Project_optionsPopover_option.disabled {
+    color: #ccc;
+    cursor: not-allowed;
+    background-color: #f9f9f9;
+}
+
+.Project_optionsPopover_option.disabled:hover {
+    background-color: #f9f9f9;
 }
 
 .Dashboard_project_description {

--- a/frontend/src/screens/Dashboard/components/Project/Project.jsx
+++ b/frontend/src/screens/Dashboard/components/Project/Project.jsx
@@ -58,15 +58,15 @@ export default function Project ({ project, date, onClick, isReview = false, pro
                                         </button>
                                         {popoverVisible && (
                                                 <div popover="auto" className='Project_optionsPopover' id={`popover-${projectIndex+1}`} >
-                                                        <div className='Project_optionsPopover_option' onClick={(e) => { e.stopPropagation(); onClick(e); }} data-testid="project-view-button">
+                                                        <div className={`Project_optionsPopover_option ${project.status === 'in_review' ? 'disabled' : ''}`} onClick={(e) => { e.stopPropagation(); if(project.status !== 'in_review') {onClick(e)} }} data-testid="project-view-button">
                                                                 <img src={view} alt="View" />
                                                                 View
                                                         </div>
-                                                        <div className='Project_optionsPopover_option' onClick={(e) => { e.stopPropagation(); handleTransferOwnership(project.proposal_id); }} data-testid="project-transfer-button">
+                                                        <div className={`Project_optionsPopover_option ${project.status === 'in_review' ? 'disabled' : ''}`} onClick={(e) => { e.stopPropagation(); if(project.status !== 'in_review') {handleTransferOwnership(project.proposal_id)} }} data-testid="project-transfer-button">
                                                                 <img className='Project_optionsPopover_option_transfer' src={transfer} alt="Transfer" />
                                                                 Transfer
                                                         </div>
-                                                        <div className='Project_optionsPopover_option' onClick={(e) => { e.stopPropagation(); handleDeleteProject(project.proposal_id); }} data-testid="project-delete-button">
+                                                        <div className={`Project_optionsPopover_option ${project.status === 'in_review' ? 'disabled' : ''}`} onClick={(e) => { e.stopPropagation(); if(project.status !== 'in_review') {handleDeleteProject(project.proposal_id)} }} data-testid="project-delete-button">
                                                                 <img className='Project_optionsPopover_option_delete' src={bin} alt="Delete" />
                                                                 Delete
                                                         </div>
@@ -85,7 +85,7 @@ export default function Project ({ project, date, onClick, isReview = false, pro
                 )
         }
 
-        return  <article className={`Dashboard_project ${popoverVisible ? 'popover-active' : ''}`} onClick={onClick} data-testid="project-card">
+        return  <article className={`Dashboard_project ${popoverVisible ? 'popover-active' : ''} ${project.status === 'in_review' ? 'disabled' : ''}`} onClick={() => project.status !== 'in_review' && onClick()} data-testid="project-card">
                         <div className="Dashboard_project_title">
                                 <h3 id={`proj-${project.proposal_id}`}>{project.project_title}</h3>
                                 <button className="Dashboard_project_tripleDotsContainer" onClick={togglePopover} aria-haspopup="true" aria-expanded={popoverVisible} data-testid="project-options-button">
@@ -93,15 +93,15 @@ export default function Project ({ project, date, onClick, isReview = false, pro
                                 </button>
                                 {popoverVisible && (
                                         <div popover="auto" className='Project_optionsPopover' id={`popover-${projectIndex+1}`} >
-                                                <div className='Project_optionsPopover_option' onClick={(e) => { e.stopPropagation(); onClick(e); }} data-testid="project-view-button">
+                                                <div className={`Project_optionsPopover_option ${project.status === 'in_review' ? 'disabled' : ''}`} onClick={(e) => { e.stopPropagation(); if(project.status !== 'in_review') {onClick(e)} }} data-testid="project-view-button">
                                                         <img src={view} alt="View" />
                                                         View
                                                 </div>
-                                                <div className='Project_optionsPopover_option' onClick={(e) => { e.stopPropagation(); handleTransferOwnership(project.proposal_id); }} data-testid="project-transfer-button">
+                                                <div className={`Project_optionsPopover_option ${project.status === 'in_review' ? 'disabled' : ''}`} onClick={(e) => { e.stopPropagation(); if(project.status !== 'in_review') {handleTransferOwnership(project.proposal_id)} }} data-testid="project-transfer-button">
                                                         <img className='Project_optionsPopover_option_transfer' src={transfer} alt="Transfer" />
                                                         Transfer
                                                 </div>
-                                                <div className='Project_optionsPopover_option' onClick={(e) => { e.stopPropagation(); handleDeleteProject(project.proposal_id); }} data-testid="project-delete-button">
+                                                <div className={`Project_optionsPopover_option ${project.status === 'in_review' ? 'disabled' : ''}`} onClick={(e) => { e.stopPropagation(); if(project.status !== 'in_review') {handleDeleteProject(project.proposal_id)} }} data-testid="project-delete-button">
                                                         <img className='Project_optionsPopover_option_delete' src={bin} alt="Delete" />
                                                         Delete
                                                 </div>

--- a/frontend/src/screens/Review/Review.jsx
+++ b/frontend/src/screens/Review/Review.jsx
@@ -75,6 +75,7 @@ export default function Review ()
 
                 if(response.ok)
                 {
+                        sessionStorage.setItem('selectedDashboardTab', 'reviews');
                         navigate("/dashboard")
                 }
                 else if(response.status === 401)


### PR DESCRIPTION
- Fixes a regression where the "..." popover menu was not visible on the "My Proposals" tab.
- Disables all edit functionality for proposals that are in "peer review" status, including the main project card and its options.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
