### PR TITLE
feat: Add associate knowledge functionality

### DIFF
--- a/backend/api/knowledge.py
+++ b/backend/api/knowledge.py
@@ -130,7 +130,7 @@ async def get_knowledge_cards(
                 params["field_context_id"] = field_context_id
 
             if filters:
-                base_query += " WHERE " + " OR ".join(filters)
+                base_query += " WHERE " + " AND ".join(filters)
 
             base_query += " ORDER BY kc.updated_at DESC"
 

--- a/backend_server.log
+++ b/backend_server.log
@@ -1,2 +1,0 @@
-INFO:     Will watch for changes in these directories: ['/app/backend']
-ERROR:    [Errno 98] Address already in use

--- a/frontend/src/components/AssociateKnowledgeModal/AssociateKnowledgeModal.jsx
+++ b/frontend/src/components/AssociateKnowledgeModal/AssociateKnowledgeModal.jsx
@@ -1,10 +1,12 @@
 import './AssociateKnowledgeModal.css'
 
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const API_BASE_URL = import.meta.env.VITE_BACKEND_URL;
 
 export default function AssociateKnowledgeModal({ isOpen, onClose, onConfirm, donorId, outcomeId, fieldContextId }) {
+  const navigate = useNavigate();
   const [options, setOptions] = useState([]);
   const [selectedOptions, setSelectedOptions] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -74,8 +76,11 @@ export default function AssociateKnowledgeModal({ isOpen, onClose, onConfirm, do
           )}
         </div>
         <div className="modal-actions">
-          <button onClick={onClose}>Cancel</button>
-          {onConfirm && <button onClick={handleConfirm} disabled={selectedOptions.length === 0}>Confirm</button>}
+          <button onClick={() => navigate('/knowledge-card/new')}>Create New Knowledge Card</button>
+          <div>
+            <button onClick={onClose}>Cancel</button>
+            {onConfirm && <button onClick={handleConfirm} disabled={selectedOptions.length === 0}>Confirm</button>}
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/screens/Chat/Chat.jsx
+++ b/frontend/src/screens/Chat/Chat.jsx
@@ -1019,14 +1019,14 @@ export default function Chat (props)
                                                                                 {renderFormField("Duration", proposalStatus !== 'draft')}
                                                                                 {renderFormField("Targeted Donor", proposalStatus !== 'draft')}
                                                                         </div>
-                                                                        <div className='Chat_form_group'>
-                                                                                <CommonButton onClick={() => setIsAssociateKnowledgeModalOpen(true)} label="Associate Knowledge" disabled={proposalStatus !== 'draft'}/>
-                                                                        </div>
                                                                 </form> : ""
                                                         }
 
                                                         <div className="Chat_inputArea_buttonContainer">
                                                                 <CommonButton onClick={handleGenerateClick} icon={generateIcon} label={generateLabel} loading={generateLoading} loadingLabel={generateLabel === "Generate" ? "Generating" : "Regenerating"} disabled={!buttonEnable || proposalStatus !== 'draft'}/>
+                                                                <div style={{ marginLeft: 'auto' }}>
+                                                                        <CommonButton onClick={() => setIsAssociateKnowledgeModalOpen(true)} label="Associate Knowledge" disabled={proposalStatus !== 'draft'} icon={<i className="fa-solid fa-book-open"></i>}/>
+                                                                </div>
                                                         </div>
                                                 </div>
                                         </>


### PR DESCRIPTION
This commit introduces the "Associate Knowledge" feature, which allows users to associate knowledge cards with a proposal.

- Adds an "Associate Knowledge" button to the chat interface.
- The button opens a modal that displays a list of knowledge cards filtered by the current context (donor, outcome, and field context).
- Users can select knowledge cards from the modal.
- The `generated_sections` of the selected cards are added to the user's prompt.
- Adds a "Create New Knowledge Card" button to the modal.
- Updates the backend API to support filtering knowledge cards.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
