### PR TITLE
Fix: Add missing statuses to proposal_status enum

### DIFF
--- a/db/database-setup.sql
+++ b/db/database-setup.sql
@@ -70,6 +70,12 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumtypid = 'proposal_status'::regtype AND enumlabel = 'deleted') THEN
         ALTER TYPE proposal_status ADD VALUE 'deleted';
     END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumtypid = 'proposal_status'::regtype AND enumlabel = 'generating_sections') THEN
+        ALTER TYPE proposal_status ADD VALUE 'generating_sections';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumtypid = 'proposal_status'::regtype AND enumlabel = 'failed') THEN
+        ALTER TYPE proposal_status ADD VALUE 'failed';
+    END IF;
 END$$;
 
 -- Create Proposals table


### PR DESCRIPTION
This commit fixes a `DatabaseError` that occurred during the asynchronous proposal generation. The error was caused by the use of the `generating_sections` and `failed` statuses, which were not defined in the `proposal_status` enum in the database.

This commit updates the `db/database-setup.sql` file to include these new statuses in the enum definition. This ensures that new database setups will have the correct schema.

The user has been informed about the manual steps required to update their existing database.

This commit builds upon the previous changes to refactor the proposal generation to be asynchronous and support parallel execution.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
