### PR TITLE
fix(crew): Fix Serper tool usage and update topic argument

### DIFF
--- a/backend/api/knowledge.py
+++ b/backend/api/knowledge.py
@@ -324,7 +324,10 @@ async def identify_references(data: IdentifyReferencesIn, current_user: dict = D
 
     try:
         crew = ReferenceIdentificationCrew()
-        result = crew.kickoff(link_type=data.linked_element, topic=data.title)
+        topic = data.title
+        if data.summary:
+            topic += f"\n{data.summary}"
+        result = crew.kickoff(link_type=data.linked_element, topic=topic)
 
         # The result from the crew should be a JSON string.
         try:

--- a/backend/utils/reference_identification_crew.py
+++ b/backend/utils/reference_identification_crew.py
@@ -1,13 +1,17 @@
+from typing import Type
+from pydantic import BaseModel, Field
 from crewai import Agent, Task, Crew
 from crewai.project import CrewBase, agent, crew, task
 from crewai_tools import SerperDevTool
 from backend.core.llm import llm
 
-class SerperSearchTool(SerperDevTool):
-    def __init__(self):
-        super().__init__()
-        self.name = "Serper Search"
-        self.description = "A search tool that uses the Serper API to find information on the web."
+class SerperSearchSchema(BaseModel):
+    search_query: str = Field(description="The search query.")
+
+class CustomSerperSearchTool(SerperDevTool):
+    name: str = "Serper Search"
+    description: str = "A search tool that uses the Serper API to find information on the web."
+    args_schema: Type[BaseModel] = SerperSearchSchema
 
 @CrewBase
 class ReferenceIdentificationCrew:
@@ -104,7 +108,7 @@ outcome with UNHCR's strategic priorities
             llm=llm,
             verbose=True,
             allow_delegation=False,
-            tools=[SerperSearchTool()]
+            tools=[CustomSerperSearchTool()]
         )
 
     @task


### PR DESCRIPTION
This change fixes the Serper Search tool usage by creating a custom tool with an explicit args_schema. This resolves the pydantic validation error where the agent was passing 'q' instead of 'search_query'.

This change also updates the topic argument passed to the reference identification crew to include both the title and summary of the knowledge card, as requested.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
