### PR TITLE
feat: Implement knowledge card content population

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -94,4 +94,15 @@ pytest-playwright
 googlesearch-python
 google-search-results
 
+# Web scraping
+beautifulsoup4
+requests
+
+# Vector embeddings
+sentence-transformers
+pgvector
+
+# PDF processing
+pypdf
+
  

--- a/backend/utils/config/content_generation_agents.yaml
+++ b/backend/utils/config/content_generation_agents.yaml
@@ -1,0 +1,9 @@
+researcher:
+  role: "Expert Researcher"
+  goal: "To find the most relevant information for a given section of a knowledge card by querying the vector database."
+  backstory: "You are an expert at sifting through large amounts of text to find the exact information needed to answer a question. You are precise and efficient."
+
+writer:
+  role: "Senior Technical Writer"
+  goal: "To write a clear, concise, and accurate section for a knowledge card based on the research provided."
+  backstory: "You are a senior technical writer at a major humanitarian organization. You are skilled at synthesizing information from various sources into a coherent and easy-to-understand narrative."

--- a/backend/utils/config/content_generation_tasks.yaml
+++ b/backend/utils/config/content_generation_tasks.yaml
@@ -1,0 +1,9 @@
+research_task:
+  description: "For the given section name and instructions, find the most relevant information from the knowledge base. The section name is '{section_name}' and the instructions are '{instructions}'. The knowledge card ID is '{knowledge_card_id}'."
+  expected_output: "A bulleted list of key findings and supporting evidence from the knowledge base that directly addresses the instructions for the section."
+
+write_task:
+  description: "Using the research findings, write the content for the section '{section_name}'. The instructions for this section are: '{instructions}'. Your response must be only the text for the section, without any additional titles or formatting."
+  expected_output: "A well-written, clear, and concise text that fulfills all the requirements of the section instructions."
+  context:
+    - research_task

--- a/backend/utils/scraper.py
+++ b/backend/utils/scraper.py
@@ -1,0 +1,33 @@
+import requests
+from bs4 import BeautifulSoup
+import logging
+
+logger = logging.getLogger(__name__)
+
+def scrape_url(url: str) -> str:
+    """
+    Scrapes the main text content from a given URL.
+    """
+    try:
+        response = requests.get(url, timeout=15)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.content, 'html.parser')
+
+        # A simple approach to get the main content:
+        # join the text of all paragraph tags.
+        # This can be improved with more sophisticated methods.
+        paragraphs = soup.find_all('p')
+        main_content = "\n".join([p.get_text() for p in paragraphs])
+
+        if not main_content:
+            # Fallback to getting all text if no paragraphs are found
+            main_content = soup.get_text(separator='\n', strip=True)
+
+        return main_content
+
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Error scraping URL {url}: {e}")
+        return None
+    except Exception as e:
+        logger.error(f"An unexpected error occurred while scraping {url}: {e}")
+        return None

--- a/db/database-setup.sql
+++ b/db/database-setup.sql
@@ -4,6 +4,10 @@
 -- Grant necessary privileges to the application user
 GRANT CONNECT ON DATABASE postgres TO <DB_USERNAME>;
 GRANT USAGE ON SCHEMA public TO <DB_USERNAME>;
+
+-- Enable vector extension
+CREATE EXTENSION IF NOT EXISTS vector;
+
 -- Create Teams table
 CREATE TABLE IF NOT EXISTS teams (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -145,11 +149,22 @@ CREATE TABLE IF NOT EXISTS knowledge_cards (
 
 -- Create Knowledge Card References table  
 CREATE TABLE IF NOT EXISTS knowledge_card_references (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     knowledge_card_id UUID NOT NULL REFERENCES knowledge_cards(id) ON DELETE CASCADE,
     url TEXT NOT NULL,
     reference_type TEXT NOT NULL,
     summary TEXT NOT NULL,
-    PRIMARY KEY (knowledge_card_id, url)
+    scraped_at TIMESTAMPTZ,
+    scraping_error BOOLEAN DEFAULT FALSE,
+    UNIQUE (knowledge_card_id, url)
+);
+
+-- Create Knowledge Card Reference Vectors table
+CREATE TABLE IF NOT EXISTS knowledge_card_reference_vectors (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    reference_id UUID NOT NULL REFERENCES knowledge_card_references(id) ON DELETE CASCADE,
+    text_chunk TEXT NOT NULL,
+    embedding vector(768)
 );
 
 -- Create join tables for many-to-many relationships  

--- a/frontend/src/screens/KnowledgeCard/KnowledgeCard.jsx
+++ b/frontend/src/screens/KnowledgeCard/KnowledgeCard.jsx
@@ -20,6 +20,8 @@ export default function KnowledgeCard() {
     const [loading, setLoading] = useState(false);
     const [loadingMessage, setLoadingMessage] = useState('');
     const [generatedSections, setGeneratedSections] = useState(null);
+    const [editingSection, setEditingSection] = useState(null);
+    const [editedContent, setEditedContent] = useState('');
 
     const [donors, setDonors] = useState([]);
     const [outcomes, setOutcomes] = useState([]);
@@ -251,6 +253,32 @@ export default function KnowledgeCard() {
         }
     }
 
+    const handleEditClick = (section, content) => {
+        setEditingSection(section);
+        setEditedContent(content);
+    };
+
+    const handleSaveClick = async (section) => {
+        const url = `${API_BASE_URL}/knowledge-cards/${id}/sections/${section}`;
+        const response = await fetch(url, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ content: editedContent }),
+            credentials: 'include'
+        });
+
+        if (response.ok) {
+            setGeneratedSections(prev => ({ ...prev, [section]: editedContent }));
+            setEditingSection(null);
+        } else {
+            alert('Failed to save section.');
+        }
+    };
+
+    const handleCancelClick = () => {
+        setEditingSection(null);
+    };
+
     return (
         <Base>
             <LoadingModal isOpen={loading} message={loadingMessage} />
@@ -353,9 +381,24 @@ export default function KnowledgeCard() {
                         {Object.entries(generatedSections).map(([section, content]) => (
                             <div key={section} className="kc-section">
                                 <h3>{section}</h3>
-                                <p>{content}</p>
+                                {editingSection === section ? (
+                                    <textarea
+                                        className="kc-edit-textarea"
+                                        value={editedContent}
+                                        onChange={(e) => setEditedContent(e.target.value)}
+                                    />
+                                ) : (
+                                    <p>{content}</p>
+                                )}
                                 <div className="kc-section-actions">
-                                    <button data-testid={`edit-section-button-${section}`}>Edit</button>
+                                    {editingSection === section ? (
+                                        <>
+                                            <button onClick={() => handleSaveClick(section)}>Save</button>
+                                            <button onClick={handleCancelClick}>Cancel</button>
+                                        </>
+                                    ) : (
+                                        <button onClick={() => handleEditClick(section, content)} data-testid={`edit-section-button-${section}`}>Edit</button>
+                                    )}
                                     <button data-testid={`regenerate-section-button-${section}`}>Regenerate</button>
                                 </div>
                             </div>

--- a/playwright/tests/test_5_knowledge_card.py
+++ b/playwright/tests/test_5_knowledge_card.py
@@ -8,7 +8,7 @@ def test_create_new_knowledge_card(page: Page):
     """
     email = "test_user@unhcr.org"
     password = "password123"
-    base_url = "http://localhost:8502"
+    base_url = "http://localhost:8503"
 
     page.goto(f"{base_url}/login")
     page.get_by_test_id("email-input").fill(email)


### PR DESCRIPTION
This commit introduces the functionality to populate knowledge cards with content.

Key features include:
- Content ingestion from web URLs and PDF files.
- A new `pgvector` based vector store to save and query scraped content.
- A new `ContentGenerationCrew` that uses `crewai` to generate content for knowledge card sections based on templates and ingested data.
- An inline editing feature on the frontend to allow manual adjustments to the generated content.
- New API endpoints to support these features.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
