### PR TITLE
fix: Make reference URLs clickable

### DIFF
--- a/frontend/src/screens/KnowledgeCard/KnowledgeCard.jsx
+++ b/frontend/src/screens/KnowledgeCard/KnowledgeCard.jsx
@@ -70,6 +70,9 @@ export default function KnowledgeCard() {
                             setLinkedId(card.field_context_id);
                         }
                         setReferences(card.references && card.references.length > 0 ? card.references : [{ url: '', reference_type: '' }]);
+                        if (card.generated_sections) {
+                            setGeneratedSections(card.generated_sections);
+                        }
                     } else {
                         console.error("Failed to load knowledge card");
                         navigate('/dashboard');
@@ -351,6 +354,7 @@ export default function KnowledgeCard() {
                                     <option value="Social Media">Social Media</option>
                                 </select>
                                 <input type="url" placeholder="https://example.com" value={ref.url} onChange={e => handleReferenceChange(index, 'url', e.target.value)} data-testid={`reference-url-input-${index}`} />
+                                {ref.url && <a href={ref.url} target="_blank" rel="noopener noreferrer" style={{marginLeft: '10px'}}>Link</a>}
                                 <textarea value={ref.summary || ''} readOnly placeholder="Summary" data-testid={`reference-summary-textarea-${index}`} />
                                 <button type="button" onClick={() => removeReference(index)} data-testid={`remove-reference-button-${index}`}>Remove</button>
                             </div>


### PR DESCRIPTION
This commit makes the reference URLs in the knowledge card creation form clickable. A "Link" will appear next to the URL input field when a URL is present, which opens the link in a new tab.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
