### PR TITLE
Fix knowledge card creation and reference identification issues

### DIFF
--- a/frontend/src/screens/KnowledgeCard/KnowledgeCard.jsx
+++ b/frontend/src/screens/KnowledgeCard/KnowledgeCard.jsx
@@ -209,14 +209,22 @@ export default function KnowledgeCard() {
     };
 
     const handleIdentifyReferences = async () => {
-        if (!id) {
-            alert("Please save the knowledge card before identifying references.");
-            return;
+        let cardId = id;
+
+        if (!cardId) {
+            const saveResponse = await handleSave(false);
+            if (!saveResponse.ok) {
+                return;
+            }
+            const data = await saveResponse.json();
+            cardId = data.knowledge_card_id;
+            navigate(`/knowledge-card/${cardId}`, { replace: true });
         }
+
         setLoading(true);
         setLoadingMessage("Identifying references...");
         try {
-            const response = await authenticatedFetch(`${API_BASE_URL}/knowledge-cards/${id}/identify-references`, {
+            const response = await authenticatedFetch(`${API_BASE_URL}/knowledge-cards/${cardId}/identify-references`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({


### PR DESCRIPTION
This commit addresses two issues related to the knowledge card feature:

1.  The frontend now automatically saves a new knowledge card when the "Identify References" button is pressed. This improves the user experience by removing the need to manually save the card first.
2.  The backend now correctly populates the `created_by`, `updated_by`, `created_at`, and `updated_at` fields when creating or updating knowledge cards and their references. This fixes a `NOT NULL` constraint violation in the database.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
