### PR TITLE
Fix knowledge card creation flow and bugs

### DIFF
--- a/backend/api/knowledge.py
+++ b/backend/api/knowledge.py
@@ -59,7 +59,7 @@ async def create_knowledge_card(card: KnowledgeCardIn, current_user: dict = Depe
     Creates a new knowledge card.
     """
     card_id = uuid.uuid4()
-    user_id = current_user['id']
+    user_id = current_user['user_id']
 
     # Ensure that only one of the foreign keys is provided.
     foreign_keys = [card.donor_id, card.outcome_id, card.field_context_id]
@@ -276,7 +276,7 @@ async def update_knowledge_card(card_id: uuid.UUID, card: KnowledgeCardIn, curre
     """
     Updates an existing knowledge card.
     """
-    user_id = current_user['id']
+    user_id = current_user['user_id']
     # Check that only one of the foreign keys is provided.
     if sum(1 for v in [card.donor_id, card.outcome_id, card.field_context_id] if v is not None) > 1:
         raise HTTPException(status_code=400, detail="A knowledge card can only be linked to one donor, outcome, or field context at a time.")

--- a/db/database-setup.sql
+++ b/db/database-setup.sql
@@ -147,7 +147,7 @@ CREATE TABLE IF NOT EXISTS knowledge_cards (
     CONSTRAINT one_link_only CHECK (
         (CASE WHEN donor_id IS NOT NULL THEN 1 ELSE 0 END +
          CASE WHEN outcome_id IS NOT NULL THEN 1 ELSE 0 END +
-         CASE WHEN field_context_id IS NOT NULL THEN 1 ELSE 0 END) = 1
+         CASE WHEN field_context_id IS NOT NULL THEN 1 ELSE 0 END) <= 1
     )
 );
 


### PR DESCRIPTION
This commit provides a comprehensive fix for several issues related to the knowledge card creation and reference identification process.

The changes include:

1.  **Frontend (KnowledgeCard.jsx):**
    -   Modified the 'Identify References' button logic to automatically save a new knowledge card before proceeding. This removes a warning message and streamlines the user workflow.

2.  **Backend (api/knowledge.py):**
    -   Corrected a `KeyError: 'id'` by using the proper `user_id` key when accessing the current user's ID from the authentication dependency.
    -   Ensured that the `created_by` and `updated_by` audit columns are correctly populated in the `knowledge_cards` and `knowledge_card_references` tables for both creation and update operations. This resolves the original `NOT NULL` constraint violation.

3.  **Database (database-setup.sql):**
    -   Relaxed the `one_link_only` `CHECK` constraint on the `knowledge_cards` table from `= 1` to `<= 1`. This allows a knowledge card to be created without an initial link to a donor, outcome, or field context, which is necessary for the new auto-save workflow.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
