### PR TITLE
Fix knowledge card creation flow and bugs

### DIFF
--- a/backend/api/knowledge.py
+++ b/backend/api/knowledge.py
@@ -546,7 +546,15 @@ async def identify_references(card_id: uuid.UUID, data: IdentifyReferencesIn, cu
         result = crew.kickoff(link_type=data.linked_element, topic=topic)
 
         try:
-            references = json.loads(result.raw)
+            # Clean the raw output from the crew
+            raw_output = result.raw.strip()
+            if raw_output.startswith("```json"):
+                raw_output = raw_output[7:]
+            if raw_output.endswith("```"):
+                raw_output = raw_output[:-3]
+            raw_output = raw_output.strip()
+
+            references = json.loads(raw_output)
         except json.JSONDecodeError:
             logger.error(f"Failed to parse JSON from crew output: {result.raw}")
             # If parsing fails, we can't proceed to store references.


### PR DESCRIPTION
This commit provides a comprehensive fix for several issues related to the knowledge card creation and reference identification process.

The changes include:

1.  **Frontend (KnowledgeCard.jsx):**
    -   Modified the 'Identify References' button logic to automatically save a new knowledge card before proceeding. This removes a warning message and streamlines the user workflow.

2.  **Backend (api/knowledge.py):**
    -   Corrected a `KeyError: 'id'` by using the proper `user_id` key when accessing the current user's ID from the authentication dependency.
    -   Ensured that the `created_by` and `updated_by` audit columns are correctly populated in the `knowledge_cards` and `knowledge_card_references` tables for both creation and update operations.
    -   Added logic to strip Markdown code fences from the raw output of the reference identification AI before parsing it as JSON, preventing a `JSONDecodeError`.

3.  **Database (database-setup.sql):**
    -   Relaxed the `one_link_only` `CHECK` constraint on the `knowledge_cards` table from `= 1` to `<= 1`. This allows a knowledge card to be created without an initial link to a donor, outcome, or field context, which is necessary for the new auto-save workflow.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
