### PR TITLE
Fix missing audit fields in identify_references endpoint

### DIFF
--- a/backend/api/knowledge.py
+++ b/backend/api/knowledge.py
@@ -560,6 +560,7 @@ async def identify_references(card_id: uuid.UUID, data: IdentifyReferencesIn, cu
             # If parsing fails, we can't proceed to store references.
             raise HTTPException(status_code=500, detail="Failed to parse references from crew output.")
 
+        user_id = current_user['user_id']
         with get_engine().begin() as connection:
             # First, clear any existing references for this card
             connection.execute(
@@ -570,14 +571,15 @@ async def identify_references(card_id: uuid.UUID, data: IdentifyReferencesIn, cu
             for ref in references:
                 connection.execute(
                     text("""
-                        INSERT INTO knowledge_card_references (knowledge_card_id, url, reference_type, summary)
-                        VALUES (:kcid, :url, :reference_type, :summary)
+                        INSERT INTO knowledge_card_references (knowledge_card_id, url, reference_type, summary, created_by, updated_by, created_at, updated_at)
+                        VALUES (:kcid, :url, :reference_type, :summary, :user_id, :user_id, NOW(), NOW())
                     """),
                     {
                         "kcid": card_id,
                         "url": ref.get("url"),
                         "reference_type": ref.get("reference_type"),
-                        "summary": ref.get("summary")
+                        "summary": ref.get("summary"),
+                        "user_id": user_id
                     }
                 )
 


### PR DESCRIPTION
This commit fixes a `NOT NULL` constraint violation that occurred when creating references in the `identify_references` endpoint. The `created_by` and `updated_by` fields were missing from the `INSERT` statement.

This is the final fix that complements the previous changes:
- Frontend auto-save on 'Identify References'.
- Corrected `KeyError` by using `user_id`.
- Relaxed `one_link_only` DB constraint.
- Cleaned JSON output from the AI crew.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
