### PR TITLE
Fix(knowledge): Add Redis fallback for knowledge card status

### DIFF
--- a/backend/core/redis.py
+++ b/backend/core/redis.py
@@ -1,5 +1,6 @@
 #  Third-Party Libraries
 import redis
+import asyncio
 
 # --- Redis Client Initialization ---
 
@@ -45,6 +46,29 @@ except redis.ConnectionError:
         def delete(self, key):
             """Deletes a key."""
             self.storage.pop(key, None)
+
+        def publish(self, channel, message):
+            """Mock publish method. Does nothing in DictStorage."""
+            pass
+
+        def pubsub(self):
+            """Mock pubsub method. Returns a mock pubsub object."""
+            return self.MockPubSub()
+
+        class MockPubSub:
+            async def subscribe(self, channel):
+                pass
+
+            async def get_message(self, ignore_subscribe_messages=True, timeout=0):
+                # This mock will not receive messages, so it returns None
+                await asyncio.sleep(timeout if timeout else 0)
+                return None
+
+            async def unsubscribe(self, channel):
+                pass
+
+            async def close(self):
+                pass
 
     # Instantiate the fallback storage.
     redis_client = DictStorage()


### PR DESCRIPTION
This commit fixes a bug that caused the application to crash when generating a knowledge card without a Redis connection. The `get_knowledge_card_status` endpoint was trying to use Redis's pub/sub functionality, which is not available when the application falls back to the in-memory `DictStorage`.

The fix implements a polling mechanism for the `get_knowledge_card_status` endpoint when `DictStorage` is in use. It also enhances the `DictStorage` class with mock `publish` and `pubsub` methods to prevent future `AttributeError`s. The `_update_progress` function is also made resilient to avoid calling `publish` on `DictStorage`.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
