### PR TITLE
Fix(knowledge): Convert CrewOutput to string before serialization

### DIFF
--- a/backend/api/knowledge.py
+++ b/backend/api/knowledge.py
@@ -531,7 +531,7 @@ async def generate_content_background(card_id: uuid.UUID):
             }
 
             result = crew.create_crew().kickoff(inputs=inputs)
-            generated_sections[section_name] = result
+            generated_sections[section_name] = str(result)
 
         with get_engine().begin() as connection:
             _update_progress(card_id, "Content generation complete.", 100)


### PR DESCRIPTION
This commit fixes a `TypeError` that occurred during the generation of knowledge card content. The `kickoff` method of the content generation crew returns a `CrewOutput` object, which is not JSON serializable. This was causing an error when the `generated_sections` dictionary was being serialized to JSON.

The fix is to convert the `CrewOutput` object to a string using `str()` before storing it in the `generated_sections` dictionary. This ensures that the dictionary is JSON serializable.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
