### PR TITLE
Redesign the 'View/Edit Knowledge Card' page

### DIFF
--- a/db/database-setup.sql
+++ b/db/database-setup.sql
@@ -132,8 +132,7 @@ CREATE TABLE IF NOT EXISTS proposal_peer_reviews (
 CREATE TABLE IF NOT EXISTS knowledge_cards (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     template_name TEXT,
-    title TEXT NOT NULL,
-    summary TEXT,
+    summary TEXT NOT NULL,
     generated_sections JSONB,
     is_accepted BOOLEAN DEFAULT FALSE,
     status proposal_status DEFAULT 'draft',

--- a/frontend/src/screens/Dashboard/components/KnowledgeCard/KnowledgeCard.jsx
+++ b/frontend/src/screens/Dashboard/components/KnowledgeCard/KnowledgeCard.jsx
@@ -2,8 +2,10 @@ import './KnowledgeCard.css'
 
 export default function KnowledgeCard({ card, onClick }) {
     let linked_to_element;
+    let title = card.summary;
 
     if (card.donor_name) {
+        title = `Donor: ${card.donor_name}`;
         linked_to_element = (
             <p>
                 <i className="fa-solid fa-money-bill-wave donor" aria-hidden="true"></i>
@@ -11,6 +13,7 @@ export default function KnowledgeCard({ card, onClick }) {
             </p>
         );
     } else if (card.outcome_name) {
+        title = `Outcome: ${card.outcome_name}`;
         linked_to_element = (
             <p>
                 <i className="fa-solid fa-bullseye outcome" aria-hidden="true"></i>
@@ -18,6 +21,7 @@ export default function KnowledgeCard({ card, onClick }) {
             </p>
         );
     } else if (card.field_context_name) {
+        title = `Field Context: ${card.field_context_name}`;
         linked_to_element = (
             <p>
                 <i className="fa-solid fa-earth-americas field-context" aria-hidden="true"></i>
@@ -31,7 +35,7 @@ export default function KnowledgeCard({ card, onClick }) {
 
     return (
         <article className="card" onClick={onClick} data-testid="knowledge-card">
-            <h3 id={`kc-${card.id}`}>{card.title}</h3>
+            <h3 id={`kc-${card.id}`}>{title}</h3>
             <p><small>{card.summary || 'No summary.'}</small></p>
             {linked_to_element}
             {card.references && card.references.length > 0 && (

--- a/frontend/src/screens/KnowledgeCard/KnowledgeCard.css
+++ b/frontend/src/screens/KnowledgeCard/KnowledgeCard.css
@@ -135,9 +135,16 @@
 }
 
 .kc-reference-card-body a {
-    color: var(--primary-color);
+    color: blue;
     text-decoration: none;
     word-break: break-all;
+}
+
+.kc-reference-card-body p {
+    font-style: italic;
+    font-size: 0.9rem;
+    color: #666;
+    margin-top: 0.5rem;
 }
 
 .kc-reference-card-body a:hover {

--- a/frontend/src/screens/KnowledgeCard/KnowledgeCard.jsx
+++ b/frontend/src/screens/KnowledgeCard/KnowledgeCard.jsx
@@ -14,7 +14,6 @@ export default function KnowledgeCard() {
     const navigate = useNavigate();
     const { id } = useParams();
 
-    const [title, setTitle] = useState('');
     const [summary, setSummary] = useState('');
     const [linkType, setLinkType] = useState('');
     const [linkedId, setLinkedId] = useState('');
@@ -58,7 +57,6 @@ export default function KnowledgeCard() {
                 if (cardRes.ok) {
                     const data = await cardRes.json();
                     const card = data.knowledge_card;
-                    setTitle(card.title);
                     setSummary(card.summary || '');
                     if (card.donor_id) {
                         setLinkType('donor');
@@ -214,7 +212,6 @@ export default function KnowledgeCard() {
         }
 
         const payload = {
-            title,
             summary,
             donor_id: linkType === 'donor' ? finalLinkedId : null,
             outcome_id: linkType === 'outcome' ? finalLinkedId : null,
@@ -266,7 +263,6 @@ export default function KnowledgeCard() {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
-                    title,
                     summary,
                     linked_element: linkType,
                 }),
@@ -435,11 +431,8 @@ export default function KnowledgeCard() {
                             </>
                         )}
 
-                        <label htmlFor="kc-title">Title*</label>
-                        <input id="kc-title" type="text" value={title} onChange={e => setTitle(e.target.value)} required data-testid="title-input" />
-
-                        <label htmlFor="kc-summary">Description</label>
-                        <textarea id="kc-summary" value={summary} onChange={e => setSummary(e.target.value)} data-testid="summary-textarea" />
+                        <label htmlFor="kc-summary">Description*</label>
+                        <textarea id="kc-summary" value={summary} onChange={e => setSummary(e.target.value)} required data-testid="summary-textarea" />
 
                         {/* References Section */}
                         <div className="kc-references-section">

--- a/jules-scratch/verification/verify_knowledge_card.py
+++ b/jules-scratch/verification/verify_knowledge_card.py
@@ -6,7 +6,8 @@ def run(playwright):
     page = context.new_page()
 
     # Navigate to the knowledge card
-    page.goto("http://localhost:8511/knowledge-card/a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d")
+    page.goto("http://localhost:8511/knowledge-card/a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d", timeout=60000)
+    page.wait_for_selector('[data-testid="add-reference-button"]')
 
     # Add a new reference
     page.get_by_test_id("add-reference-button").click()


### PR DESCRIPTION
This commit redesigns the 'View/Edit Knowledge Card' page to be more compact and aligned with the rest of the app.

The changes include:
- A new card-based design for the references section, with add, edit, and delete functionality.
- The generated content section is now responsive.
- The 'Regenerate' button has been removed from each section.
- The edit box for a section is now full-width when editing.
- A history snapshot is now recorded whenever the knowledge card content is regenerated or a section is edited.
- The 'Title' field has been removed from the knowledge card, and 'Description' is now the main compulsory field.
- The dashboard now uses the 'link to' variable as the knowledge card title.
- The reference link is now styled with blue color font, and the summary is in italic with a smaller font.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
