### PR TITLE
Fix(proposals): Add created_by to proposal creation

### DIFF
--- a/backend/api/proposals.py
+++ b/backend/api/proposals.py
@@ -97,8 +97,8 @@ async def create_session(request: CreateSessionRequest, current_user: dict = Dep
             # Create the main proposal record
             connection.execute(
                 text("""
-                    INSERT INTO proposals (id, user_id, form_data, project_description, template_name, generated_sections)
-                    VALUES (:id, :uid, :form, :desc, :template, '{}')
+                    INSERT INTO proposals (id, user_id, created_by, form_data, project_description, template_name, generated_sections)
+                    VALUES (:id, :uid, :uid, :form, :desc, :template, '{}')
                 """),
                 {
                     "id": proposal_id,


### PR DESCRIPTION
The 'created_by' column in the 'proposals' table has a NOT NULL constraint, but it was not being set when a new proposal was created.

This change modifies the INSERT statement in the 'create_session' function to include the 'created_by' column, setting its value to the ID of the user creating the proposal.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
