### PR TITLE
Fix proposal generation and knowledge card creation bugs

### DIFF
--- a/backend/api/proposals.py
+++ b/backend/api/proposals.py
@@ -97,8 +97,8 @@ async def create_session(request: CreateSessionRequest, current_user: dict = Dep
             # Create the main proposal record
             connection.execute(
                 text("""
-                    INSERT INTO proposals (id, user_id, created_by, form_data, project_description, template_name, generated_sections)
-                    VALUES (:id, :uid, :uid, :form, :desc, :template, '{}')
+                    INSERT INTO proposals (id, user_id, created_by, updated_by, form_data, project_description, template_name, generated_sections)
+                    VALUES (:id, :uid, :uid, :uid, :form, :desc, :template, '{}')
                 """),
                 {
                     "id": proposal_id,
@@ -541,7 +541,6 @@ async def save_draft(request: SaveDraftRequest, current_user: dict = Depends(get
                         "form": json.dumps(request.form_data),
                         "desc": request.project_description,
                         "sections": json.dumps(sections_to_save),
-                        "sections": json.dumps(sections_to_save),
                         "id": proposal_id,
                         "template_name": request.template_name
                     }
@@ -551,15 +550,14 @@ async def save_draft(request: SaveDraftRequest, current_user: dict = Depends(get
                 # Insert a new draft.
                 connection.execute(
                     text("""
-                        INSERT INTO proposals (id, user_id, form_data, project_description, generated_sections, template_name)
-                        VALUES (:id, :uid, :form, :desc, :sections, :template_name)
+                        INSERT INTO proposals (id, user_id, created_by, updated_by, form_data, project_description, generated_sections, template_name)
+                        VALUES (:id, :uid, :uid, :uid, :form, :desc, :sections, :template_name)
                     """),
                     {
                         "id": proposal_id,
                         "uid": user_id,
                         "form": json.dumps(request.form_data),
                         "desc": request.project_description,
-                        "sections": json.dumps(sections_to_save),
                         "sections": json.dumps(sections_to_save),
                         "template_name": request.template_name
                     }

--- a/frontend/src/screens/KnowledgeCard/KnowledgeCard.jsx
+++ b/frontend/src/screens/KnowledgeCard/KnowledgeCard.jsx
@@ -505,10 +505,10 @@ export default function KnowledgeCard() {
                         </div>
                         <div className="kc-form-actions">
                             <div className="kc-form-actions-left">
-                                <CommonButton type="submit" label="Populate Card Content" loading={loading} disabled={loading || !title} className="squared-btn" data-testid="populate-card-button" />
+                                <CommonButton type="submit" label="Populate Card Content" loading={loading} disabled={loading || !summary} className="squared-btn" data-testid="populate-card-button" />
                             </div>
                             <div className="kc-form-actions-right">
-                                <CommonButton type="button" onClick={() => handleSave(true)} label="Save Card" loading={loading} disabled={loading || !title} data-testid="save-card-button" />
+                                <CommonButton type="button" onClick={() => handleSave(true)} label="Save Card" loading={loading} disabled={loading || !summary} data-testid="save-card-button" />
                             </div>
                         </div>
                     </form>


### PR DESCRIPTION
This commit fixes two bugs:

1.  **Proposal Generation Error:** The `create-session` endpoint was failing with a 500 error due to a `NOT NULL` constraint violation on the `updated_by` column in the `proposals` table. This was fixed by adding the `updated_by` field to the `INSERT` statements in the `create_session` and `save_draft` functions in `backend/api/proposals.py`.

2.  **Knowledge Card Creation Error:** The "Create New Knowledge Card" screen had a `ReferenceError: title is not defined`, which prevented the "Populate Card Content" and "Save Card" buttons from being enabled. This was fixed by replacing the undefined `title` variable with the `summary` state variable in `frontend/src/screens/KnowledgeCard/KnowledgeCard.jsx`.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
