### PR TITLE
Fix: Adjust chat layout and resolve create session error

### DIFF
--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -70,6 +70,7 @@ class CreateSessionRequest(BaseModel):
     """
     form_data: Dict[str, Any]
     project_description: str
+    associated_knowledge_cards: Optional[List[Dict[str, Any]]] = None
 
 
 class UpdateSectionRequest(BaseModel):

--- a/frontend/src/screens/Chat/Chat.css
+++ b/frontend/src/screens/Chat/Chat.css
@@ -693,6 +693,8 @@
 }
 
 .associated-knowledge-display ul {
+    max-height: 150px;
+    overflow-y: auto;
     list-style-type: none;
     padding-left: 0;
     margin-bottom: 0;

--- a/frontend/src/screens/Chat/Chat.jsx
+++ b/frontend/src/screens/Chat/Chat.jsx
@@ -1035,7 +1035,8 @@ export default function Chat (props)
                                                         }
 
                                                         <div className="Chat_inputArea_buttonContainer">
-                                                                <div>
+                                                                <div style={{ position: 'relative' }}>
+                                                                        <CommonButton onClick={() => setIsAssociateKnowledgeModalOpen(true)} label="Associate Knowledge" disabled={proposalStatus !== 'draft'} icon={knowIcon}/>
                                                                         {associatedKnowledgeCards.length > 0 && (
                                                                                 <div className="associated-knowledge-display">
                                                                                         <h4>Associated Knowledge Cards:</h4>
@@ -1046,11 +1047,10 @@ export default function Chat (props)
                                                                                         </ul>
                                                                                 </div>
                                                                         )}
-                                                                        <CommonButton onClick={() => setIsAssociateKnowledgeModalOpen(true)} label="Associate Knowledge" disabled={proposalStatus !== 'draft'} icon={knowIcon}/>
                                                                 </div>
                                                                 
                                                                 <div style={{ marginLeft: 'auto' }}>
-                                                                <CommonButton onClick={handleGenerateClick} icon={generateIcon} label={generateLabel} loading={generateLoading} loadingLabel={generateLabel === "Generate" ? "Generating" : "Regenerating"} disabled={!buttonEnable || proposalStatus !== 'draft'}/>
+                                                                        <CommonButton onClick={handleGenerateClick} icon={generateIcon} label={generateLabel} loading={generateLoading} loadingLabel={generateLabel === "Generate" ? "Generating" : "Regenerating"} disabled={!buttonEnable || proposalStatus !== 'draft'}/>
                                                                 </div>
                                                         </div>
                                                 </div>


### PR DESCRIPTION
This commit addresses two issues:

1.  **Frontend Layout:** The "Associated Knowledge Cards" display in `chat.jsx` is now positioned below the "Associate Knowledge" button. The list of cards is also made scrollable to prevent it from taking up too much vertical space.

2.  **Backend Error:** The `CreateSessionRequest` model in `backend/models/schemas.py` was missing the `associated_knowledge_cards` field, which caused an `AttributeError` when creating a new proposal session with associated knowledge. This field has been added to the model to resolve the error.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
