### PR TITLE
Fix: Display generated sections in KnowledgeCard

### DIFF
--- a/frontend/src/screens/KnowledgeCard/KnowledgeCard.jsx
+++ b/frontend/src/screens/KnowledgeCard/KnowledgeCard.jsx
@@ -978,8 +978,7 @@ export default function KnowledgeCard() {
                 {generatedSections && Object.keys(generatedSections).length > 0 && (
                     <div className="kc-content-container">
                         <h2>Generated Content</h2>
-                        {proposal_template?.sections?.map(sectionInfo => {
-                            const section = sectionInfo.section_name;
+                        {Object.keys(generatedSections).map(section => {
                             const content = generatedSections[section];
                             // Only show sections that have content
                             if (!content) return null;


### PR DESCRIPTION
The rendering logic for generated content in `KnowledgeCard.jsx` was previously dependent on `proposal_template`. This could cause a race condition or mismatches, preventing generated sections from being displayed.

This commit changes the rendering logic to iterate directly over the keys of the `generatedSections` object. This ensures that any available generated content is displayed immediately, whether on initial load or after being generated in real-time.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
