### PR TITLE
fix: resolve multiple issues in chat and knowledge association

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -116,13 +116,13 @@ async def login(request: Request):
         
         # 3. Create a JWT token and set Redis session
         token = jwt.encode(
-            {"email": email, "exp": datetime.utcnow() + timedelta(minutes=30)},
+            {"email": email, "exp": datetime.utcnow() + timedelta(minutes=480)},
             SECRET_KEY,
             algorithm="HS256"
         )
         
         try:
-            redis_client.setex(f"user_session:{user_id}", 1800, token)
+            redis_client.setex(f"user_session:{user_id}", 28800, token)
         except RedisError as redis_error:
             # Catch specific Redis-related errors
             logging.error(f"Redis error setting session for user ID {user_id}: {redis_error}")
@@ -139,7 +139,7 @@ async def login(request: Request):
             value=token,
             httponly=True,
             path="/",
-            max_age=1800,
+            max_age=28800,
             **cookie_settings
         )
         logging.info(f"User {email} logged in successfully.")

--- a/frontend/src/screens/Chat/Chat.jsx
+++ b/frontend/src/screens/Chat/Chat.jsx
@@ -288,6 +288,7 @@ export default function Chat (props)
                                                         options={getOptions(label)}
                                                         value={getOptions(label).find(o => o.value === field.value)}
                                                         isDisabled={disabled}
+                                                        inputId={fieldId}
                                                 />
                                         </div>
                                 ) : isCreatableMultiSelect ? (
@@ -301,6 +302,7 @@ export default function Chat (props)
                                                         options={getOptions(label)}
                                                         value={field.value.map(v => getOptions(label).find(o => o.value === v)).filter(Boolean)}
                                                         isDisabled={disabled}
+                                                        inputId={fieldId}
                                                 />
                                         </div>
                                 ) : isNormalSelect ? (
@@ -656,6 +658,9 @@ export default function Chat (props)
                         if (response.ok) {
                                 const data = await response.json();
                                 setStatusHistory(data.statuses);
+                        } else if (response.status === 403) {
+                                // If forbidden, user doesn't have rights, so we don't show history.
+                                setStatusHistory([]);
                         }
                 }
         }
@@ -956,6 +961,7 @@ export default function Chat (props)
                                 donorId={formData["Targeted Donor"].value}
                                 outcomeId={formData["Main Outcome"].value}
                                 fieldContextId={formData["Country / Location(s)"].value}
+                                initialSelection={associatedKnowledgeCards}
                         />
                         {((!isMobile && sidebarOpen) || (isMobile && isMobileMenuOpen)) && <aside>
                                 <ul className='Chat_sidebar'>


### PR DESCRIPTION
This commit addresses several bugs and improves the user experience in the chat and knowledge card association features.

- feat(auth): Extend session and token expiration to 8 hours to prevent intermittent 401 Unauthorized errors during long user sessions.

- fix(chat): Gracefully handle 403 Forbidden errors when fetching proposal status history, preventing console errors for users without permission.

- fix(accessibility): Add `inputId` to `CreatableSelect` components to correctly associate labels with form controls, improving accessibility.

- feat(knowledge): Enhance the 'Associate Knowledge' modal to allow de-association of cards by enabling the confirm button when the selection changes.

- fix(knowledge): Ensure the list of associated knowledge cards is correctly displayed in the chat component.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
