### PR TITLE
fix: resolve FileNotFound and UI bugs in knowledge association

### DIFF
--- a/backend/api/proposals.py
+++ b/backend/api/proposals.py
@@ -205,7 +205,9 @@ async def generate_all_sections_background(session_id: str, proposal_id: str, us
                     knowledge_content.append(card["generated_sections"])
 
             if knowledge_content:
-                with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix=".json") as temp_file:
+                tmp_dir = os.path.join("knowledge", "tmp")
+                os.makedirs(tmp_dir, exist_ok=True)
+                with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix=".json", dir=tmp_dir) as temp_file:
                     json.dump(knowledge_content, temp_file)
                     knowledge_file_path = temp_file.name
 

--- a/frontend/src/screens/Chat/Chat.jsx
+++ b/frontend/src/screens/Chat/Chat.jsx
@@ -288,6 +288,7 @@ export default function Chat (props)
                                                         options={getOptions(label)}
                                                         value={getOptions(label).find(o => o.value === field.value)}
                                                         isDisabled={disabled}
+                                                        inputId={fieldId}
                                                 />
                                         </div>
                                 ) : isCreatableMultiSelect ? (
@@ -301,6 +302,7 @@ export default function Chat (props)
                                                         options={getOptions(label)}
                                                         value={field.value.map(v => getOptions(label).find(o => o.value === v)).filter(Boolean)}
                                                         isDisabled={disabled}
+                                                        inputId={fieldId}
                                                 />
                                         </div>
                                 ) : isNormalSelect ? (
@@ -656,6 +658,9 @@ export default function Chat (props)
                         if (response.ok) {
                                 const data = await response.json();
                                 setStatusHistory(data.statuses);
+                        } else if (response.status === 403) {
+                                // If forbidden, user doesn't have rights, so we don't show history.
+                                setStatusHistory([]);
                         }
                 }
         }
@@ -956,6 +961,7 @@ export default function Chat (props)
                                 donorId={formData["Targeted Donor"].value}
                                 outcomeId={formData["Main Outcome"].value}
                                 fieldContextId={formData["Country / Location(s)"].value}
+                                initialSelection={associatedKnowledgeCards}
                         />
                         {((!isMobile && sidebarOpen) || (isMobile && isMobileMenuOpen)) && <aside>
                                 <ul className='Chat_sidebar'>


### PR DESCRIPTION
This commit addresses a backend error and several UI issues related to the 'Associate Knowledge' feature.

- fix(backend): Ensure the temporary directory `knowledge/tmp` exists and create the temporary knowledge card file within it to prevent `FileNotFoundError` during proposal generation.

- feat(knowledge): Enhance the 'Associate Knowledge' modal to allow de-association of cards by enabling the confirm button only when the selection has changed from its initial state.

- fix(knowledge): Correctly pass the initial selection of associated cards to the modal to ensure they are displayed and can be modified.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
