### PR TITLE
Fix: Correctly parse generated_sections in knowledge card API

### DIFF
--- a/backend/api/knowledge.py
+++ b/backend/api/knowledge.py
@@ -358,7 +358,15 @@ async def update_knowledge_card_section(card_id: uuid.UUID, section_name: str, s
             if not result or not result.generated_sections:
                 raise HTTPException(status_code=404, detail="Knowledge card or sections not found.")
 
-            generated_sections = json.loads(result.generated_sections)
+            generated_sections = result.generated_sections
+            if isinstance(generated_sections, str):
+                try:
+                    generated_sections = json.loads(generated_sections)
+                except json.JSONDecodeError:
+                    raise HTTPException(status_code=500, detail="Failed to parse existing sections.")
+
+            if not isinstance(generated_sections, dict):
+                 raise HTTPException(status_code=500, detail="Existing sections are not in a valid format.")
 
             if section_name not in generated_sections:
                 raise HTTPException(status_code=404, detail=f"Section '{section_name}' not found.")


### PR DESCRIPTION
The `update_knowledge_card_section` endpoint was failing to correctly parse the `generated_sections` field from the database. The code was using a direct `json.loads()` call, which would raise an error if the database driver had already deserialized the `JSONB` column into a Python dictionary.

This change replaces the direct call with a more robust parsing logic that checks the type of the `generated_sections` field first. It now handles both string and dictionary types, preventing potential errors when editing and saving a knowledge card section. This robust logic is consistent with other endpoints in the API that handle the same data.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
