### PR TITLE
Fix: Concatenate knowledge card title in Chat.jsx

### DIFF
--- a/frontend/src/mocks/server.js
+++ b/frontend/src/mocks/server.js
@@ -205,5 +205,21 @@ export const server = setupServer(
 
         http.post(`${API_BASE_URL}/finalize-proposal`, () =>
                 HttpResponse.json({ success: true })
-        )
+        ),
+
+        http.get(`${API_BASE_URL}/metrics/development-time`, () => {
+                return HttpResponse.json({ "Proposal": 30, "Revision": 15 });
+        }),
+
+        http.get(`${API_BASE_URL}/metrics/funding-by-category`, () => {
+                return HttpResponse.json({ "Health": 5, "Education": 10 });
+        }),
+
+        http.get(`${API_BASE_URL}/metrics/donor-interest`, () => {
+                return HttpResponse.json({ "USAID": 20, "UNICEF": 5 });
+        }),
+
+        http.get(`${API_BASE_URL}/knowledge-cards`, () => {
+                return HttpResponse.json({ knowledge_cards: [] });
+        })
 )

--- a/frontend/src/screens/Chat/Chat.jsx
+++ b/frontend/src/screens/Chat/Chat.jsx
@@ -1047,9 +1047,15 @@ export default function Chat (props)
                                                                                 <div className="associated-knowledge-display">
                                                                                         <h4>Associated Knowledge Cards:</h4>
                                                                                         <ul>
-                                                                                                {associatedKnowledgeCards.map(card => (
-                                                                                                        <li key={card.id}>{card.title}</li>
-                                                                                                ))}
+                                                                                                {associatedKnowledgeCards.map(card => {
+                                                                                                        const title = [
+                                                                                                                card.title,
+                                                                                                                card.donor_name,
+                                                                                                                card.outcome_name,
+                                                                                                                card.field_context_name,
+                                                                                                        ].filter(Boolean).join(' - ');
+                                                                                                        return (<li key={card.id}>{title}</li>);
+                                                                                                })}
                                                                                         </ul>
                                                                                 </div>
                                                                         )}

--- a/frontend/src/screens/Chat/Chat.test.jsx
+++ b/frontend/src/screens/Chat/Chat.test.jsx
@@ -14,6 +14,18 @@ describe('Proposal Drafter – Form validation', () => {
                         }),
                         http.get('http://localhost:8502/api/profile', () => {
                                 return HttpResponse.json({ user: { "email": "test@test.com", "name": "Test User" } })
+                        }),
+                        http.get('http://localhost:8502/api/donors', () => {
+                                return HttpResponse.json({ donors: [{id: '1', name: 'USAID'}] });
+                        }),
+                        http.get('http://localhost:8502/api/outcomes', () => {
+                                return HttpResponse.json({ outcomes: [{id: '1', name: 'OA1-Access/Documentation'}] });
+                        }),
+                        http.get('http://localhost:8502/api/field-contexts', () => {
+                                return HttpResponse.json({ field_contexts: [{id: '1', name: 'USA', geographic_coverage: 'One Country Operation'}] });
+                        }),
+                        http.get('http://localhost:8502/api/users', () => {
+                                return HttpResponse.json({ users: [] });
                         })
                 )
                 render(
@@ -34,7 +46,7 @@ describe('Proposal Drafter – Form validation', () => {
                 await waitFor(() => expect(generateButton).toBeDisabled())
 
                 const geographicalScopeInput = screen.getByTestId('geographical-scope')
-                await userEvent.selectOptions(geographicalScopeInput, 'One Area')
+                await userEvent.selectOptions(geographicalScopeInput, 'One Country Operation')
                 await waitFor(() => expect(generateButton).toBeDisabled())
 
                 const countryInput = screen.getByLabelText(/Country \/ Location\(s\)/i)
@@ -60,7 +72,7 @@ describe('Proposal Drafter – Form validation', () => {
                 const donorInput = screen.getByLabelText(/Targeted Donor/i)
                 await userEvent.type(donorInput, 'USAID{enter}')
                 await waitFor(() => expect(generateButton).toBeEnabled())
-        })
+        }, 20000)
 })
 
 describe('Proposal Drafter – One‑Section Generation Flow', () => {
@@ -68,6 +80,18 @@ describe('Proposal Drafter – One‑Section Generation Flow', () => {
                 server.use(
                         http.get('http://localhost:8502/api/templates', () => HttpResponse.json({ templates: { "UNHCR": {} } })),
                         http.get('http://localhost:8502/api/profile', () => HttpResponse.json({ user: { "email": "test@test.com", "name": "Test User" } })),
+                        http.get('http://localhost:8502/api/donors', () => {
+                                return HttpResponse.json({ donors: [{id: '1', name: 'USAID'}] });
+                        }),
+                        http.get('http://localhost:8502/api/outcomes', () => {
+                                return HttpResponse.json({ outcomes: [{id: '1', name: 'OA1-Access/Documentation'}] });
+                        }),
+                        http.get('http://localhost:8502/api/field-contexts', () => {
+                                return HttpResponse.json({ field_contexts: [{id: '1', name: 'USA', geographic_coverage: 'One Country Operation'}] });
+                        }),
+                        http.get('http://localhost:8502/api/users', () => {
+                                return HttpResponse.json({ users: [] });
+                        }),
                         http.post('http://localhost:8502/api/create-session', () => {
                                 return HttpResponse.json({
                                         session_id: 'test-session-id',
@@ -80,9 +104,18 @@ describe('Proposal Drafter – One‑Section Generation Flow', () => {
                                         }
                                 })
                         }),
-                        http.post('http://localhost:8502/api/process_section/:session_id', async ({request}) => {
-                                const body = await request.json()
-                                return HttpResponse.json({ generated_text: `Mocked text for ${body.section}` })
+                        http.post('http://localhost:8502/api/generate-proposal-sections/:session_id', async ({request}) => {
+                                return new HttpResponse(null, { status: 200 });
+                        }),
+                        http.get('http://localhost:8502/api/proposals/:proposal_id/status', async ({request}) => {
+                                return HttpResponse.json({ status: 'done', generated_sections: {
+                                        'Summary': 'Mocked text for Summary',
+                                        'Rationale': 'Mocked text for Rationale',
+                                        'Project Description': 'Mocked text for Project Description',
+                                        'Partnerships and Coordination': 'Mocked text for Partnerships and Coordination',
+                                        'Monitoring': 'Mocked text for Monitoring',
+                                        'Evaluation': 'Mocked text for Evaluation',
+                                }})
                         })
                 )
                 render(
@@ -96,7 +129,7 @@ describe('Proposal Drafter – One‑Section Generation Flow', () => {
                 const mainOutcomeButton = screen.getByLabelText('Main Outcome')
                 await userEvent.type(mainOutcomeButton, 'OA1-Access/Documentation{enter}')
                 const geographicalScopeInput = screen.getByTestId('geographical-scope')
-                await userEvent.selectOptions(geographicalScopeInput, 'One Area')
+                await userEvent.selectOptions(geographicalScopeInput, 'One Country Operation')
                 await userEvent.type(screen.getByLabelText(/Country \/ Location\(s\)/i), 'USA{enter}')
                 await userEvent.type(screen.getByLabelText(/Beneficiaries Profile/i), 'Students')
                 await userEvent.type(screen.getByLabelText(/Duration/i), '12 months{enter}')
@@ -111,12 +144,24 @@ describe('Proposal Drafter – One‑Section Generation Flow', () => {
                         const card = await screen.findByText(new RegExp(`Mocked text for ${sec}`, 'i'), { timeout: 10000 });
                         expect(card).toBeInTheDocument();
                 }
-        })
+        }, 20000)
 
         it('allows editing Summary content', async () => {
                 server.use(
                         http.get('http://localhost:8502/api/templates', () => HttpResponse.json({ templates: { "UNHCR": {} } })),
                         http.get('http://localhost:8502/api/profile', () => HttpResponse.json({ user: { "email": "test@test.com", "name": "Test User" } })),
+                        http.get('http://localhost:8502/api/donors', () => {
+                                return HttpResponse.json({ donors: [{id: '1', name: 'USAID'}] });
+                        }),
+                        http.get('http://localhost:8502/api/outcomes', () => {
+                                return HttpResponse.json({ outcomes: [{id: '1', name: 'OA1-Access/Documentation'}] });
+                        }),
+                        http.get('http://localhost:8502/api/field-contexts', () => {
+                                return HttpResponse.json({ field_contexts: [{id: '1', name: 'USA', geographic_coverage: 'One Country Operation'}] });
+                        }),
+                        http.get('http://localhost:8502/api/users', () => {
+                                return HttpResponse.json({ users: [] });
+                        }),
                         http.post('http://localhost:8502/api/create-session', () => {
                                 return HttpResponse.json({
                                         session_id: 'test-session-id',
@@ -129,9 +174,18 @@ describe('Proposal Drafter – One‑Section Generation Flow', () => {
                                         }
                                 })
                         }),
-                        http.post('http://localhost:8502/api/process_section/:session_id', async ({request}) => {
-                                const body = await request.json()
-                                return HttpResponse.json({ generated_text: `Mocked text for ${body.section}` })
+                        http.post('http://localhost:8502/api/generate-proposal-sections/:session_id', async ({request}) => {
+                                return new HttpResponse(null, { status: 200 });
+                        }),
+                        http.get('http://localhost:8502/api/proposals/:proposal_id/status', async ({request}) => {
+                                return HttpResponse.json({ status: 'done', generated_sections: {
+                                        'Summary': 'Mocked text for Summary',
+                                        'Rationale': 'Mocked text for Rationale',
+                                        'Project Description': 'Mocked text for Project Description',
+                                        'Partnerships and Coordination': 'Mocked text for Partnerships and Coordination',
+                                        'Monitoring': 'Mocked text for Monitoring',
+                                        'Evaluation': 'Mocked text for Evaluation',
+                                }})
                         }),
                         http.post('http://localhost:8502/api/update-section-content', async ({request}) => {
                                 const body = await request.json()
@@ -149,7 +203,7 @@ describe('Proposal Drafter – One‑Section Generation Flow', () => {
                 const mainOutcomeButton = screen.getByLabelText('Main Outcome')
                 await userEvent.type(mainOutcomeButton, 'OA1-Access/Documentation{enter}')
                 const geographicalScopeInput = screen.getByTestId('geographical-scope')
-                await userEvent.selectOptions(geographicalScopeInput, 'One Area')
+                await userEvent.selectOptions(geographicalScopeInput, 'One Country Operation')
                 await userEvent.type(screen.getByLabelText(/Country \/ Location\(s\)/i), 'USA{enter}')
                 await userEvent.type(screen.getByLabelText(/Beneficiaries Profile/i), 'Students')
                 await userEvent.type(screen.getByLabelText(/Duration/i), '12 months{enter}')
@@ -181,26 +235,42 @@ describe('Proposal Drafter – One‑Section Generation Flow', () => {
 
                 const regenerated = await screen.findByText(/Custom Summary Text/i)
                 expect(regenerated).toBeInTheDocument()
-        }),
+        }, 20000),
 
         it('hides the input form when a finalized proposal is loaded', async () => {
                 server.use(
                         http.get('http://localhost:8502/api/templates', () => HttpResponse.json({ templates: { "UNHCR": {} } })),
                         http.get('http://localhost:8502/api/profile', () => HttpResponse.json({ user: { "email": "test@test.com", "name": "Test User" } })),
+                        http.get('http://localhost:8502/api/donors', () => {
+                                return HttpResponse.json({ donors: [{id: '1', name: 'USAID'}] });
+                        }),
+                        http.get('http://localhost:8502/api/outcomes', () => {
+                                return HttpResponse.json({ outcomes: [{id: '1', name: 'OA1-Access/Documentation'}] });
+                        }),
+                        http.get('http://localhost:8502/api/field-contexts', () => {
+                                return HttpResponse.json({ field_contexts: [{id: '1', name: 'USA', geographic_coverage: 'One Country Operation'}] });
+                        }),
+                        http.get('http://localhost:8502/api/users', () => {
+                                return HttpResponse.json({ users: [] });
+                        }),
                         http.get('http://localhost:8502/api/load-draft/:proposal_id', () => {
                                 return HttpResponse.json({
                                         proposal_id: 'approved-proposal-123',
                                         session_id: 'test-session-id',
                                         project_description: 'test description',
                                         form_data: {
-                                                "Project Draft Short name": "test project", "Main Outcome": ["OA1-Access/Documentation"],
+                                                "Project Draft Short name": "test project", "Main Outcome": ["1"],
                                                 "Beneficiaries Profile": "test beneficiaries", "Potential Implementing Partner": "test partner",
-                                                "Geographical Scope": "test scope", "Country / Location(s)": "test country",
-                                                "Budget Range": "1M$", "Duration": "12 months", "Targeted Donor": "USAID"
+                                                "Geographical Scope": "One Country Operation", "Country / Location(s)": "1",
+                                                "Budget Range": "1M$", "Duration": "12 months", "Targeted Donor": "1"
                                         },
                                         generated_sections: { 'Summary': 'Mocked text for Summary' },
-                                        is_accepted: true
+                                        is_accepted: true,
+                                        status: 'approved'
                                 })
+                        }),
+                        http.get('http://localhost:8502/api/proposals/:proposal_id/status-history', () => {
+                                return HttpResponse.json({ statuses: [] });
                         })
                 )
 


### PR DESCRIPTION
The associated knowledge card display in `Chat.jsx` was not rendering the card titles correctly because the `title` property was sometimes undefined. This change fixes the issue by concatenating the card's `title`, `donor_name`, `outcome_name`, and `field_context_name` to create a descriptive title, similar to how it's displayed in `AssociateKnowledgeModal.jsx`.

This also includes updates to the tests to ensure they pass with the new logic and to fix existing test failures.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
