### PR TITLE
fix: Prevent clearing of Country/Location field on load

### DIFF
--- a/frontend/src/screens/Chat/Chat.jsx
+++ b/frontend/src/screens/Chat/Chat.jsx
@@ -163,15 +163,17 @@ export default function Chat (props)
 
         useEffect(() => {
                 const scope = formData['Geographical Scope'].value;
-                if (scope) {
-                        const filtered = fieldContexts.filter(fc => fc.geographic_coverage === scope);
-                        setFilteredFieldContexts(filtered);
-                } else {
-                        setFilteredFieldContexts(fieldContexts);
-                }
+                const filtered = scope
+                        ? fieldContexts.filter(fc => fc.geographic_coverage === scope)
+                        : fieldContexts;
+                setFilteredFieldContexts(filtered);
 
-                if (formData['Country / Location(s)'].value) {
-                    handleFormInput({ target: { value: "" } }, "Country / Location(s)");
+                const locationValue = formData['Country / Location(s)'].value;
+                if (locationValue) {
+                    const isLocationStillValid = filtered.some(fc => fc.id === locationValue);
+                    if (fieldContexts.length > 0 && !isLocationStillValid) {
+                        handleFormInput({ target: { value: "" } }, "Country / Location(s)");
+                    }
                 }
         }, [formData['Geographical Scope'].value, fieldContexts]);
         function handleFormInput (e, label) {


### PR DESCRIPTION
The `useEffect` hook that manages the 'Country / Location(s)' field was incorrectly clearing the value when a proposal was loaded. This was because the dependency array caused the effect to run on initial data population.

This change modifies the `useEffect` to only clear the 'Country / Location(s)' field if the selected location is no longer valid after a change in the 'Geographical Scope'. This ensures that when a saved proposal is opened, the value is correctly displayed.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
