### PR TITLE
feat: Use associated knowledge cards in proposal generation

### DIFF
--- a/backend/utils/crew.py
+++ b/backend/utils/crew.py
@@ -13,11 +13,11 @@ from backend.core.llm import llm, get_embedder_config
 class ProposalCrew():
     """ProposalCrew for generating project proposal"""
 
-    def __init__(self, knowledge_file_path: str = None):
-        self.knowledge_file_path = knowledge_file_path
+    def __init__(self, knowledge_file_paths: list[str] = None):
+        self.knowledge_file_paths = knowledge_file_paths
         self.json_knowledge = None
-        if self.knowledge_file_path:
-            self.json_knowledge = JSONKnowledgeSource(file_paths=[self.knowledge_file_path])
+        if self.knowledge_file_paths:
+            self.json_knowledge = JSONKnowledgeSource(file_paths=self.knowledge_file_paths)
 
     agents_config = 'config/agents.yaml'
     tasks_config = 'config/tasks.yaml'


### PR DESCRIPTION
This commit updates the proposal generation logic to use the knowledge card files associated with the proposal. The `ProposalCrew` is now initialized with a list of file paths for the selected knowledge cards, allowing the crew to ground the proposal generation in the relevant content.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
