### PR TITLE
fix(backend): Handle dict type for generated_sections

### DIFF
--- a/backend/api/knowledge.py
+++ b/backend/api/knowledge.py
@@ -425,7 +425,9 @@ async def update_knowledge_card_section(card_id: uuid.UUID, section_name: str, s
             if not result or not result.generated_sections:
                 raise HTTPException(status_code=404, detail="Knowledge card or sections not found.")
 
-            generated_sections = json.loads(result.generated_sections)
+            generated_sections = result.generated_sections
+            if isinstance(generated_sections, str):
+                generated_sections = json.loads(generated_sections)
 
             if section_name not in generated_sections:
                 raise HTTPException(status_code=404, detail=f"Section '{section_name}' not found.")


### PR DESCRIPTION
The `update_knowledge_card_section` function would fail with a `TypeError` if the `generated_sections` field from the database was already a dictionary, as it would unconditionally try to call `json.loads` on it.

This change adds a check to see if `generated_sections` is a string before attempting to deserialize it, aligning its behavior with other functions in the same file that handle this field.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
