### PR TITLE
Fix: Pass knowledge_card_id to crew to prevent UUID error

### DIFF
--- a/backend/api/knowledge.py
+++ b/backend/api/knowledge.py
@@ -874,7 +874,7 @@ async def generate_content_background(card_id: uuid.UUID):
 
         template = load_proposal_template(template_name)
         generated_sections = {}
-        crew = ContentGenerationCrew()
+        crew = ContentGenerationCrew(knowledge_card_id=str(card_id))
 
         num_sections = len(template.get("sections", []))
         for i, section in enumerate(template.get("sections", [])):
@@ -886,7 +886,6 @@ async def generate_content_background(card_id: uuid.UUID):
             inputs = {
                 "section_name": section_name,
                 "instructions": instructions,
-                "knowledge_card_id": str(card_id),
             }
 
             # Add timeout and error handling for each section


### PR DESCRIPTION
The ContentGenerationCrew was incorrectly using a string from the task description as the `knowledge_card_id` for a vector search, causing a database error due to an invalid UUID format.

This was resolved by refactoring the `ContentGenerationCrew` and its `VectorSearchTool` to accept the `knowledge_card_id` during initialization.

The API layer was updated to pass the `card_id` when creating the crew, ensuring the correct UUID is used and preventing the agent from having to infer the ID from the prompt.

- Does my code meet the quality standards for releasing packages?
- Does the reviewer have all the information to validate the features/issues without too much research?
- Does the customer who will validate the associated tickets have the information to do so without wasting time?

## Issues to validate to close : 

- [ ] issue #


## Processed issues to keep open or in progress: 

- [ ] issue #

## Checklist:

- [ ] Does the package check go local?
- [ ] Does the CI pass?
- [ ] Are the added / fixed features documented, tested?
- [ ] Are the added features / solved problems briefly presented in the PR message?
- [ ] Are the changes related to tickets / issues that I have listed in the commits and in the PR itself?
- [ ] Are the tickets in "review" mode in the Project Tracking Board?
- [ ] Does each ticket, if it is to be closed after acceptance of the PR, contain a comment that tells how to validate it?
 
